### PR TITLE
Enable high resolution textures on map

### DIFF
--- a/IKriegsspiel/Assets/Resources/Entire map (colorized) big.png.meta
+++ b/IKriegsspiel/Assets/Resources/Entire map (colorized) big.png.meta
@@ -31,7 +31,7 @@ TextureImporter:
   cubemapConvolution: 0
   seamlessCubemap: 0
   textureFormat: 1
-  maxTextureSize: 2048
+  maxTextureSize: 8192
   textureSettings:
     serializedVersion: 2
     filterMode: 1
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1
@@ -82,7 +82,7 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 4
     buildTarget: Standalone
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1
@@ -95,7 +95,7 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 4
     buildTarget: WebGL
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/IKriegsspiel/Assets/Scripts/Map.cs
+++ b/IKriegsspiel/Assets/Scripts/Map.cs
@@ -7,6 +7,8 @@ public class Map : MonoBehaviour
     public Texture2D texture;
     public float dynamicFriction = 1f;
     public float staticFriction = 1f;
+    [Tooltip("Maximum size of a single tile texture in pixels")]
+    public int tileSize = 4096;
 
     void Awake()
     {
@@ -40,14 +42,72 @@ public class Map : MonoBehaviour
         }
         if (texture != null)
         {
-            var rend = GetComponent<MeshRenderer>();
-            // use a shader that works with the Universal Render Pipeline
-            var shader = Shader.Find("Universal Render Pipeline/Unlit");
-            if (shader == null)
-                shader = Shader.Find("Unlit/Texture");
-            var mat = new Material(shader);
-            mat.mainTexture = texture;
-            rend.material = mat;
+            ApplyTexture(texture);
+        }
+    }
+
+    void ApplyTexture(Texture2D tex)
+    {
+        if (tex.width <= tileSize && tex.height <= tileSize)
+        {
+            ApplySingle(tex);
+        }
+        else
+        {
+            ApplyTiled(tex);
+        }
+    }
+
+    void ApplySingle(Texture2D tex)
+    {
+        var rend = GetComponent<MeshRenderer>();
+        var shader = Shader.Find("Universal Render Pipeline/Unlit");
+        if (shader == null)
+            shader = Shader.Find("Unlit/Texture");
+        var mat = new Material(shader);
+        mat.mainTexture = tex;
+        rend.material = mat;
+    }
+
+    void ApplyTiled(Texture2D tex)
+    {
+        var baseRenderer = GetComponent<MeshRenderer>();
+        var size = baseRenderer.bounds.size;
+        float unitsPerPixelX = size.x / tex.width;
+        float unitsPerPixelZ = size.z / tex.height;
+        baseRenderer.enabled = false;
+
+        var shader = Shader.Find("Universal Render Pipeline/Unlit");
+        if (shader == null)
+            shader = Shader.Find("Unlit/Texture");
+
+        int tilesX = Mathf.CeilToInt(tex.width / (float)tileSize);
+        int tilesY = Mathf.CeilToInt(tex.height / (float)tileSize);
+
+        for (int y = 0; y < tilesY; y++)
+        {
+            for (int x = 0; x < tilesX; x++)
+            {
+                int w = Mathf.Min(tileSize, tex.width - x * tileSize);
+                int h = Mathf.Min(tileSize, tex.height - y * tileSize);
+
+                var tileTex = new Texture2D(w, h, tex.format, false);
+                tileTex.SetPixels(tex.GetPixels(x * tileSize, y * tileSize, w, h));
+                tileTex.Apply();
+
+                var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+                quad.name = $"Tile_{x}_{y}";
+                quad.transform.SetParent(transform, false);
+                quad.transform.localScale = new Vector3(w * unitsPerPixelX, h * unitsPerPixelZ, 1f);
+                float posX = -size.x / 2f + (x * tileSize + w / 2f) * unitsPerPixelX;
+                float posZ = -size.z / 2f + (y * tileSize + h / 2f) * unitsPerPixelZ;
+                quad.transform.localPosition = new Vector3(posX, 0f, posZ);
+
+                var qrend = quad.GetComponent<MeshRenderer>();
+                var mat = new Material(shader);
+                mat.mainTexture = tileTex;
+                qrend.material = mat;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- support high resolution map textures via tiling in `Map.cs`
- bump `maxTextureSize` for the default large map texture to 8192

## Testing
- `echo "No test suite present"`

------
https://chatgpt.com/codex/tasks/task_e_68486ecafdb0832d8e7dcc99ca3ee699