### PR TITLE
Adjust rotation controls and remove outline effect

### DIFF
--- a/IKriegsspiel/Assets/Scripts/CameraController.cs
+++ b/IKriegsspiel/Assets/Scripts/CameraController.cs
@@ -119,8 +119,6 @@ public class CameraController : MonoBehaviour
     void SelectUnit(Unit unit)
     {
         if (selectedUnit == unit) return;
-        if (selectedUnit != null) selectedUnit.SetSelected(false);
         selectedUnit = unit;
-        if (selectedUnit != null) selectedUnit.SetSelected(true);
     }
 }

--- a/IKriegsspiel/Assets/Scripts/DragAndDrop.cs
+++ b/IKriegsspiel/Assets/Scripts/DragAndDrop.cs
@@ -71,7 +71,14 @@ public class DragAndDrop : MonoBehaviour
 
         float scroll = Mouse.current.scroll.ReadValue().y;
         if (Mathf.Abs(scroll) > Mathf.Epsilon)
-            grabbed.transform.Rotate(Vector3.up, scroll * rotateSpeed, Space.World);
+        {
+            float angle = scroll * rotateSpeed;
+            if (Keyboard.current != null && Keyboard.current.shiftKey.isPressed)
+            {
+                angle = Mathf.Sign(angle) * 1f;
+            }
+            grabbed.transform.Rotate(Vector3.up, angle, Space.World);
+        }
     }
 
     void EndDrag()

--- a/IKriegsspiel/Assets/Scripts/Unit.cs
+++ b/IKriegsspiel/Assets/Scripts/Unit.cs
@@ -5,7 +5,7 @@ public class Unit : MonoBehaviour
 {
     public Texture2D texture;
     public float decalHeightOffset = 0.01f;
-    GameObject selectionIndicator;
+
 
     void Awake()
     {
@@ -30,8 +30,7 @@ public class Unit : MonoBehaviour
         if (rb != null)
             rb.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
 
-        CreateSelectionIndicator();
-        SetSelected(false);
+
     }
 
     void ApplyTexture(Texture2D tex)
@@ -72,35 +71,5 @@ public class Unit : MonoBehaviour
         rend.material = mat;
     }
 
-    void CreateSelectionIndicator()
-    {
-        var collider = GetComponent<Collider>();
-        if (collider == null) return;
 
-        var bounds = collider.bounds;
-        GameObject ring = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
-        Destroy(ring.GetComponent<Collider>());
-        ring.name = "SelectionIndicator";
-        ring.transform.SetParent(transform, false);
-
-        float radiusX = bounds.size.x * 1.1f;
-        float radiusZ = bounds.size.z * 1.1f;
-        ring.transform.localScale = new Vector3(radiusX / transform.lossyScale.x, 0.05f, radiusZ / transform.lossyScale.z);
-        ring.transform.localPosition = Vector3.zero;
-        var rend = ring.GetComponent<MeshRenderer>();
-        var outlineShader = Shader.Find("Universal Render Pipeline/Unlit");
-        if (outlineShader == null)
-            outlineShader = Shader.Find("Unlit/Color");
-        var outlineMat = new Material(outlineShader);
-        outlineMat.color = Color.yellow;
-        rend.material = outlineMat;
-        ring.SetActive(false);
-        selectionIndicator = ring;
-    }
-
-    public void SetSelected(bool selected)
-    {
-        if (selectionIndicator != null)
-            selectionIndicator.SetActive(selected);
-    }
 }


### PR DESCRIPTION
## Summary
- remove ring-based selection outline
- update rotation so shift limits to 1 degree per scroll step

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b895ad74832db7a1e8a1ba0be3f7