### PR TITLE
Add delete key removal for units

### DIFF
--- a/IKriegsspiel/Assets/Scripts/CameraController.cs
+++ b/IKriegsspiel/Assets/Scripts/CameraController.cs
@@ -27,6 +27,7 @@ public class CameraController : MonoBehaviour
         HandleRotate();
         HandleSelection();
         HandleCopyPaste();
+        HandleDelete();
     }
 
     void HandleMove()
@@ -113,6 +114,17 @@ public class CameraController : MonoBehaviour
                 GameObject obj = Instantiate(copyBuffer.gameObject, hit.point, copyBuffer.transform.rotation);
                 SelectUnit(obj.GetComponent<Unit>());
             }
+        }
+    }
+
+    void HandleDelete()
+    {
+        if (Keyboard.current == null) return;
+        if (selectedUnit == null) return;
+        if (Keyboard.current.deleteKey.wasPressedThisFrame)
+        {
+            Destroy(selectedUnit.gameObject);
+            selectedUnit = null;
         }
     }
 


### PR DESCRIPTION
## Summary
- allow CameraController to delete the currently selected unit when the `Delete` key is pressed

## Testing
- `dotnet --list-sdks` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ca75515c832dae0ed2c4f20761fa