### PR TITLE
Add texture selection via context menu

### DIFF
--- a/IKriegsspiel/Assets/Scripts/Map.cs
+++ b/IKriegsspiel/Assets/Scripts/Map.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 [RequireComponent(typeof(Collider))]
 [RequireComponent(typeof(MeshRenderer))]
+[RequireComponent(typeof(TextureContextMenu))]
 public class Map : MonoBehaviour
 {
     public Texture2D texture;
@@ -46,7 +47,7 @@ public class Map : MonoBehaviour
         }
     }
 
-    void ApplyTexture(Texture2D tex)
+    public void ApplyTexture(Texture2D tex)
     {
         if (tex.width <= tileSize && tex.height <= tileSize)
         {

--- a/IKriegsspiel/Assets/Scripts/TextureContextMenu.cs
+++ b/IKriegsspiel/Assets/Scripts/TextureContextMenu.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+public class TextureContextMenu : MonoBehaviour
+{
+#if UNITY_EDITOR
+    void OnMouseOver()
+    {
+        if (Mouse.current != null && Mouse.current.rightButton.wasPressedThisFrame)
+        {
+            ShowMenu();
+        }
+    }
+
+    void ShowMenu()
+    {
+        var menu = new GenericMenu();
+        menu.AddItem(new GUIContent("Select texture"), false, OnSelectTexture);
+        Vector2 pos = Mouse.current.position.ReadValue();
+        pos.y = Screen.height - pos.y;
+        menu.DropDown(new Rect(pos, Vector2.zero));
+    }
+
+    void OnSelectTexture()
+    {
+        string path = EditorUtility.OpenFilePanel("Select texture", "", "png,jpg,jpeg");
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        byte[] data = System.IO.File.ReadAllBytes(path);
+        var tex = new Texture2D(2, 2);
+        tex.LoadImage(data);
+
+        var unit = GetComponent<Unit>();
+        if (unit != null)
+        {
+            unit.texture = tex;
+            unit.ApplyTexture(tex);
+            return;
+        }
+        var map = GetComponent<Map>();
+        if (map != null)
+        {
+            map.texture = tex;
+            map.ApplyTexture(tex);
+        }
+    }
+#endif
+}

--- a/IKriegsspiel/Assets/Scripts/TextureContextMenu.cs.meta
+++ b/IKriegsspiel/Assets/Scripts/TextureContextMenu.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 86af3b129dfa4098884ce6c0bd5ac32f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - icon: {instanceID: 0}
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IKriegsspiel/Assets/Scripts/Unit.cs
+++ b/IKriegsspiel/Assets/Scripts/Unit.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 
 [RequireComponent(typeof(Collider))]
+[RequireComponent(typeof(TextureContextMenu))]
 public class Unit : MonoBehaviour
 {
     public Texture2D texture;
@@ -33,7 +34,7 @@ public class Unit : MonoBehaviour
 
     }
 
-    void ApplyTexture(Texture2D tex)
+    public void ApplyTexture(Texture2D tex)
     {
         Transform top = transform.Find("Top");
         if (top == null)


### PR DESCRIPTION
## Summary
- update `Map` and `Unit` so they auto-add `TextureContextMenu`
- expose `ApplyTexture` to allow runtime updates
- add `TextureContextMenu` component with editor file dialog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849be805bf8832dad4d1c835432e542