### PR TITLE
Implement runtime texture selection via context menu

### DIFF
--- a/IKriegsspiel/Assets/Scenes/SampleScene.unity
+++ b/IKriegsspiel/Assets/Scenes/SampleScene.unity
@@ -409,6 +409,8 @@ GameObject:
   - component: {fileID: 679798068}
   - component: {fileID: 679798067}
   - component: {fileID: 679798066}
+  - component: {fileID: 679798072}
+  - component: {fileID: 679798073}
   m_Layer: 0
   m_Name: unit (1)
   m_TagString: Untagged
@@ -546,6 +548,31 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &679798072
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 679798065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86af3b129dfa4098884ce6c0bd5ac32f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &679798073
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 679798065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a1f1f0baddf48478d1b9e4c25cc3c72, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 0}
 --- !u!1 &832575517
 GameObject:
   m_ObjectHideFlags: 0
@@ -608,6 +635,8 @@ GameObject:
   - component: {fileID: 1570000002}
   - component: {fileID: 1570000001}
   - component: {fileID: 1570000005}
+  - component: {fileID: 1570000006}
+  - component: {fileID: 1570000007}
   m_Layer: 0
   m_Name: map
   m_TagString: Untagged
@@ -720,6 +749,31 @@ MonoBehaviour:
   dynamicFriction: 1
   staticFriction: 1
   tileSize: 4096
+--- !u!114 &1570000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1570000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86af3b129dfa4098884ce6c0bd5ac32f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1570000007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1570000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a1f1f0baddf48478d1b9e4c25cc3c72, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 0}
 --- !u!1 &1570000100
 GameObject:
   m_ObjectHideFlags: 0
@@ -780,6 +834,8 @@ GameObject:
   - component: {fileID: 2081671767}
   - component: {fileID: 2081671772}
   - component: {fileID: 2081671771}
+  - component: {fileID: 2081671773}
+  - component: {fileID: 2081671774}
   m_Layer: 0
   m_Name: unit
   m_TagString: Untagged
@@ -917,6 +973,31 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   texture: {fileID: 2800000, guid: 1fb23b9acf9c4ed44b42779267139763, type: 3}
   decalHeightOffset: 0.01
+--- !u!114 &2081671773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081671766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86af3b129dfa4098884ce6c0bd5ac32f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2081671774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081671766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a1f1f0baddf48478d1b9e4c25cc3c72, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/IKriegsspiel/Assets/Scripts/ContextMenuManager.cs
+++ b/IKriegsspiel/Assets/Scripts/ContextMenuManager.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+using System.IO;
+
+public class ContextMenuManager : MonoBehaviour
+{
+    public Camera cam;
+
+    bool menuOpen;
+    Object targetObject; // Map or Unit
+    Vector2 menuPosition;
+
+    void Start()
+    {
+        if (cam == null)
+            cam = Camera.main;
+    }
+
+    void Update()
+    {
+        if (Mouse.current == null)
+            return;
+
+        if (Mouse.current.rightButton.wasPressedThisFrame)
+            TryOpenMenu();
+
+        if (menuOpen && Mouse.current.leftButton.wasPressedThisFrame)
+            menuOpen = false;
+    }
+
+    void TryOpenMenu()
+    {
+        Ray ray = cam.ScreenPointToRay(Mouse.current.position.ReadValue());
+        if (Physics.Raycast(ray, out RaycastHit hit))
+        {
+            var unit = hit.collider.GetComponentInParent<Unit>();
+            var map = hit.collider.GetComponentInParent<Map>();
+            if (unit != null)
+                targetObject = unit;
+            else if (map != null)
+                targetObject = map;
+            else
+                return;
+
+            menuOpen = true;
+            var mousePos = Mouse.current.position.ReadValue();
+            menuPosition = new Vector2(mousePos.x, Screen.height - mousePos.y);
+        }
+    }
+
+    void OnGUI()
+    {
+        if (!menuOpen || targetObject == null)
+            return;
+
+        const float width = 120f;
+        const float height = 25f;
+        Rect rect = new Rect(menuPosition.x, menuPosition.y, width, height);
+        if (GUI.Button(rect, "Select texture"))
+        {
+            SelectTexture();
+            menuOpen = false;
+        }
+    }
+
+    void SelectTexture()
+    {
+#if UNITY_EDITOR
+        string path = EditorUtility.OpenFilePanel("Select texture", "", "png,jpg,jpeg");
+        if (!string.IsNullOrEmpty(path))
+        {
+            byte[] data = File.ReadAllBytes(path);
+            Texture2D tex = new Texture2D(2, 2);
+            tex.LoadImage(data);
+            if (targetObject is Unit u)
+                u.SetTexture(tex);
+            else if (targetObject is Map m)
+                m.SetTexture(tex);
+        }
+#endif
+    }
+}

--- a/IKriegsspiel/Assets/Scripts/ContextMenuManager.cs.meta
+++ b/IKriegsspiel/Assets/Scripts/ContextMenuManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0a1f1f0baddf48478d1b9e4c25cc3c72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - icon: {instanceID: 0}
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IKriegsspiel/Assets/Scripts/Map.cs
+++ b/IKriegsspiel/Assets/Scripts/Map.cs
@@ -46,6 +46,16 @@ public class Map : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Replace the current map texture at runtime.
+    /// </summary>
+    /// <param name="tex">Texture to display on the map.</param>
+    public void SetTexture(Texture2D tex)
+    {
+        texture = tex;
+        ApplyTexture(tex);
+    }
+
     void ApplyTexture(Texture2D tex)
     {
         if (tex.width <= tileSize && tex.height <= tileSize)

--- a/IKriegsspiel/Assets/Scripts/Unit.cs
+++ b/IKriegsspiel/Assets/Scripts/Unit.cs
@@ -33,6 +33,16 @@ public class Unit : MonoBehaviour
 
     }
 
+    /// <summary>
+    /// Replace the current unit texture at runtime.
+    /// </summary>
+    /// <param name="tex">Texture to apply on the top side.</param>
+    public void SetTexture(Texture2D tex)
+    {
+        texture = tex;
+        ApplyTexture(tex);
+    }
+
     void ApplyTexture(Texture2D tex)
     {
         Transform top = transform.Find("Top");


### PR DESCRIPTION
## Summary
- allow units and maps to replace textures at runtime
- implement `ContextMenuManager` to open system file dialog on right‑click
- wire up texture application through new public `SetTexture` methods

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6849dee51c88832d8004c6d6f7c4ed0c